### PR TITLE
Fix(api): Sort GeckoTerminal pools by creation date

### DIFF
--- a/smart_money_tracker.py
+++ b/smart_money_tracker.py
@@ -43,15 +43,15 @@ def scan_for_new_pools():
     print("Step 1: SCANNING for new and active token pools...")
     potential_tokens = []
 
-    # GeckoTerminal API returns pools sorted by latest creation time by default.
-    # We will paginate through the results.
+    # We will paginate through the results, sorting by creation time to get the newest pools first.
     page = 1
     # Limit to a reasonable number of pages to avoid infinite loops in edge cases.
     max_pages = 10
 
     while page <= max_pages:
         print(f"Scanning page {page}...")
-        url = f"{GECKOTERMINAL_API_URL}/networks/bsc/pools?page={page}"
+        # Add the 'sort=created_at_desc' parameter to fetch newest pools first.
+        url = f"{GECKOTERMINAL_API_URL}/networks/bsc/pools?page={page}&sort=created_at_desc"
 
         try:
             response = requests.get(url)


### PR DESCRIPTION
The script was previously failing to find new pools because the GeckoTerminal API was returning pools sorted by popularity or volume by default, not by creation time. This caused the script to encounter old pools on the first page and terminate its scan prematurely.

This change corrects the behavior by adding the `sort=created_at_desc` query parameter to the API request in the `scan_for_new_pools` function. This ensures that the API returns pools sorted from newest to oldest, allowing the script to correctly identify and process new pools as intended.

The associated comments have also been updated to reflect the new sorting logic.